### PR TITLE
feat(mouse): add click_at tool to improve approval workflow

### DIFF
--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -12,7 +12,8 @@ import {
   getCursorPosition,
   scrollMouse,
   dragMouse,
-  setMouseSpeed
+  setMouseSpeed,
+  clickAt
 } from "../tools/mouse.js";
 import { 
   typeText, 
@@ -42,6 +43,24 @@ export function setupTools(server: Server): void {
   // List available tools
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: [
+      {
+        name: "click_at",
+        description: "Move mouse to coordinates, click, then return to original position",
+        inputSchema: {
+          type: "object",
+          properties: {
+            x: { type: "number", description: "X coordinate" },
+            y: { type: "number", description: "Y coordinate" },
+            button: { 
+              type: "string", 
+              enum: ["left", "right", "middle"],
+              default: "left",
+              description: "Mouse button to click" 
+            }
+          },
+          required: ["x", "y"]
+        }
+      },
       {
         name: "move_mouse",
         description: "Move the mouse cursor to specific coordinates",
@@ -377,6 +396,17 @@ export function setupTools(server: Server): void {
       let response;
 
       switch (name) {
+        case "click_at":
+          if (typeof args?.x !== 'number' || typeof args?.y !== 'number') {
+            throw new Error("Invalid click_at arguments");
+          }
+          response = await clickAt(
+            args.x,
+            args.y,
+            typeof args?.button === 'string' ? args.button : 'left'
+          );
+          break;
+
         case "move_mouse":
           if (!isMousePosition(args)) {
             throw new Error("Invalid mouse position arguments");

--- a/src/tools/mouse.test.ts
+++ b/src/tools/mouse.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import libnut from '@nut-tree/libnut';
+import { clickAt, moveMouse, clickMouse } from './mouse.js';
+
+// Mock libnut
+vi.mock('@nut-tree/libnut', () => ({
+  default: {
+    moveMouse: vi.fn(),
+    mouseClick: vi.fn(),
+    getMousePos: vi.fn()
+  }
+}));
+
+describe('Mouse Tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Setup default mock for getMousePos
+    (libnut.getMousePos as any).mockReturnValue({ x: 0, y: 0 });
+  });
+
+  describe('clickAt', () => {
+    it('should move to position, click, and return to original position', async () => {
+      // Mock original position
+      (libnut.getMousePos as any).mockReturnValue({ x: 10, y: 20 });
+
+      const result = await clickAt(100, 200);
+
+      // Verify the sequence of operations
+      expect(libnut.getMousePos).toHaveBeenCalledTimes(1);
+      expect(libnut.moveMouse).toHaveBeenCalledTimes(2);
+      expect(libnut.mouseClick).toHaveBeenCalledTimes(1);
+
+      // Verify the correct coordinates were used
+      expect(libnut.moveMouse).toHaveBeenNthCalledWith(1, 100, 200);
+      expect(libnut.moveMouse).toHaveBeenNthCalledWith(2, 10, 20);
+      expect(libnut.mouseClick).toHaveBeenCalledWith('left');
+
+      // Verify success response
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('Clicked left button at position (100, 200)');
+    });
+
+    it('should support different mouse buttons', async () => {
+      const result = await clickAt(100, 200, 'right');
+
+      expect(libnut.mouseClick).toHaveBeenCalledWith('right');
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('Clicked right button');
+    });
+
+    it('should handle invalid coordinates', async () => {
+      const result = await clickAt(NaN, 200);
+
+      expect(libnut.moveMouse).not.toHaveBeenCalled();
+      expect(libnut.mouseClick).not.toHaveBeenCalled();
+      expect(result.success).toBe(false);
+      expect(result.message).toBe('Invalid coordinates provided');
+    });
+
+    it('should handle errors during mouse operations', async () => {
+      (libnut.moveMouse as any).mockRejectedValue(new Error('Mouse movement failed'));
+
+      const result = await clickAt(100, 200);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('Failed to click at position');
+    });
+  });
+});

--- a/src/tools/mouse.ts
+++ b/src/tools/mouse.ts
@@ -128,6 +128,38 @@ export async function dragMouse(from: MousePosition, to: MousePosition, button: 
   }
 }
 
+export async function clickAt(x: number, y: number, button: keyof ButtonMap = 'left'): Promise<WindowsControlResponse> {
+  if (typeof x !== 'number' || typeof y !== 'number' || isNaN(x) || isNaN(y)) {
+    return {
+      success: false,
+      message: 'Invalid coordinates provided'
+    };
+  }
+  try {
+    // Store original position
+    const originalPosition = await libnut.getMousePos();
+    
+    // Move to target position
+    await libnut.moveMouse(x, y);
+    
+    // Perform click
+    await libnut.mouseClick(buttonMap[button]);
+    
+    // Return to original position
+    await libnut.moveMouse(originalPosition.x, originalPosition.y);
+    
+    return {
+      success: true,
+      message: `Clicked ${button} button at position (${x}, ${y}) and returned to (${originalPosition.x}, ${originalPosition.y})`
+    };
+  } catch (error) {
+    return {
+      success: false,
+      message: `Failed to click at position: ${error instanceof Error ? error.message : String(error)}`
+    };
+  }
+}
+
 export async function setMouseSpeed(speed: number): Promise<WindowsControlResponse> {
   try {
     // Speed is in milliseconds. Lower values = faster movement


### PR DESCRIPTION
This commit adds a new click_at tool that combines mouse movement and clicking into a single atomic operation, specifically designed to improve the approval workflow:

Problem:
When clients require approval for mouse actions, the user moving their mouse to approve breaks the model's intended workflow since the mouse position changes between operations.

Solution:
- Stores original mouse position before any movement
- Moves to target coordinates
- Performs click with specified button (left/right/middle)
- Returns mouse to original position automatically

Key improvements:
- Maintains workflow integrity during approval processes
- Prevents user mouse movements from interfering with model actions
- Reduces number of approval steps needed
- Includes comprehensive test coverage
- Handles invalid inputs and error cases

Example usage:
await clickAt(500, 300); // Click at coordinates with left button await clickAt(100, 200, 'right'); // Right click at coordinates